### PR TITLE
Recommend Raspberry Pi Pico 2 W in installation guide

### DIFF
--- a/docs/gc/picoboot/installation-guide.md
+++ b/docs/gc/picoboot/installation-guide.md
@@ -33,7 +33,7 @@ Affiliate links below help support the project at no extra cost to you. Thank yo
    - Raspberry Pi Pico
    - Raspberry Pi Pico W
    - Raspberry Pi Pico 2
-   - Raspberry Pi Pico 2 W
+   - Raspberry Pi Pico 2 W (recommended)
 2. SD card adapter like GC2SD, SD Gecko, WiiSD or SD2SP2:
    - SD2SP2: If you have DOL-001 with Serial Port 2 (<ShoppingButton url="https://s.click.aliexpress.com/e/_olfXufh" />)
    - GC2SD/WiiSD/SD Gecko: If you have DOL-001 with Serial Port 2 (<ShoppingButton url="https://s.click.aliexpress.com/e/_onzxcOR" />)


### PR DESCRIPTION
Update the installation guide to recommend the Raspberry Pi Pico 2 W as per https://github.com/webhdx/PicoBoot/issues/142#issuecomment-3456820585